### PR TITLE
Invalidate cached chart index file after publishing

### DIFF
--- a/hack/publish.sh
+++ b/hack/publish.sh
@@ -10,4 +10,10 @@ helm repo index stable/ --url https://charts.appscode.com/stable/
 gsutil rsync -d -r stable gs://appscode-charts/stable
 gsutil acl ch -u AllUsers:R -r gs://appscode-charts/stable
 
+sleep 10
+
+gcloud compute url-maps invalidate-cdn-cache cdn \
+  --host charts.appscode.com \
+  --path "/stable/index.yaml"
+
 popd


### PR DESCRIPTION
ref: https://cloud.google.com/cdn/docs/invalidating-cached-content

Signed-off-by: Tamal Saha <tamal@appscode.com>