### PR TITLE
Support selective chart publishing via arguments

### DIFF
--- a/hack/scripts/publish-oci-charts.sh
+++ b/hack/scripts/publish-oci-charts.sh
@@ -40,11 +40,21 @@ REGISTRY_2=${REGISTRY_2:-}
 mkdir -p $SCRIPT_ROOT/.oci
 cd $SCRIPT_ROOT/.oci
 
-for file in $SCRIPT_ROOT/$CHARTS_DIR/*; do
-    if [ -d "$file" ]; then
-        helm package "$file"
-    fi
-done
+if [ $# -gt 2 ]; then
+    # Loop over the chart names provided as arguments
+    for chart in "${@:3}"; do
+        if [ -d "$SCRIPT_ROOT/$CHARTS_DIR/$chart" ]; then
+            helm package "$SCRIPT_ROOT/$CHARTS_DIR/$chart"
+        fi
+    done
+else
+    # Loop over all charts
+    for file in $SCRIPT_ROOT/$CHARTS_DIR/*; do
+        if [ -d "$file" ]; then
+            helm package "$file"
+        fi
+    done
+fi
 
 for file in $SCRIPT_ROOT/.oci/*; do
     if [ -n "$REGISTRY_0" ]; then


### PR DESCRIPTION
This PR enhances the publish-oci-charts.sh script to support publishing specific charts by passing their names as arguments.

## Changes
- Modified the script to check if more than 2 arguments are provided
- If yes, loops over chart names provided as arguments (3+) and publishes only those
- If no, maintains original behavior of publishing all charts in the directory

## Usage
- `./publish-oci-charts.sh [root] [charts_dir]` - publishes all charts (original behavior)
- `./publish-oci-charts.sh [root] [charts_dir] chart1 chart2 chart3` - publishes only specified charts

## Benefits
- Faster publishing when only specific charts need updates
- More flexible deployment workflow
- Reduces unnecessary chart publishing