### PR TITLE
Replace hub CLI with gh CLI in scripts and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run checks
         run: |

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Publish to GitHub Container Registry
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,6 @@ jobs:
           aws configure set s3.signature_version s3v4
           aws configure set endpoint_url $AWS_S3_ENDPOINT
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Install Helm 3
         run: |
           echo "install helm 3"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Configure S3 CLI
         env:

--- a/hack/scripts/open-pr.sh
+++ b/hack/scripts/open-pr.sh
@@ -119,14 +119,14 @@ while true; do
     #  open pr
     pr_cmd=$(
         cat <<EOF
-hub pull-request \
-    --message "Publish $pr_branch charts" \
-    --message "$(git show -s --format=%b)"
+gh pr create \
+    --title "Publish $pr_branch charts" \
+    --body "$(git show -s --format=%b)"
 EOF
     )
     # if no Release-tracker: auto merge.
     if [ -z "$RELEASE_TRACKER" ]; then
-        pr_cmd="$pr_cmd --labels automerge"
+        pr_cmd="$pr_cmd --label automerge"
     fi
     eval "$pr_cmd" || true
     # if Release-tracker: found, report back.
@@ -134,7 +134,7 @@ EOF
         parse_url $RELEASE_TRACKER
         api_url="repos/${RELEASE_TRACKER_OWNER}/${RELEASE_TRACKER_REPO}/issues/${RELEASE_TRACKER_PR}/comments"
         msg="/chart github.com/${GITHUB_REPOSITORY} ${GIT_TAG}"
-        hub api "$api_url" -f body="$msg"
+        gh api "$api_url" -f body="$msg"
     fi
     exit 0
 done

--- a/hack/scripts/publish.sh
+++ b/hack/scripts/publish.sh
@@ -89,4 +89,4 @@ done 9< <(git show -s --format=%b)
 parse_url $RELEASE_TRACKER
 api_url="repos/${RELEASE_TRACKER_OWNER}/${RELEASE_TRACKER_REPO}/issues/${RELEASE_TRACKER_PR}/comments"
 msg="/chart-published github.com/${GITHUB_REPOSITORY}"
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"

--- a/hack/scripts/upload-charts.sh
+++ b/hack/scripts/upload-charts.sh
@@ -115,14 +115,14 @@ while true; do
     #  open pr
     pr_cmd=$(
         cat <<EOF
-hub pull-request \
-    --message "Publish $pr_branch charts" \
-    --message "$(git show -s --format=%b)"
+gh pr create \
+    --title "Publish $pr_branch charts" \
+    --body "$(git show -s --format=%b)"
 EOF
     )
     # if no Release-tracker: auto merge.
     if [ -z "$RELEASE_TRACKER" ]; then
-        pr_cmd="$pr_cmd --labels automerge"
+        pr_cmd="$pr_cmd --label automerge"
     fi
     eval "$pr_cmd" || true
     # if Release-tracker: found, report back.
@@ -130,7 +130,7 @@ EOF
         parse_url $RELEASE_TRACKER
         api_url="repos/${RELEASE_TRACKER_OWNER}/${RELEASE_TRACKER_REPO}/issues/${RELEASE_TRACKER_PR}/comments"
         msg="/chart github.com/${GITHUB_REPOSITORY} ${GIT_TAG}"
-        hub api "$api_url" -f body="$msg"
+        gh api "$api_url" -f body="$msg"
     fi
     exit 0
 done


### PR DESCRIPTION
## Summary
- Replace deprecated `hub` CLI with `gh` in `hack/scripts/{publish,open-pr,upload-charts}.sh` (`hub pull-request --message/--message` → `gh pr create --title/--body`, `--labels` → `--label`, `hub api` → `gh api`).
- Drop the `hub` install step from `.github/workflows/publish.yml` — `gh` is preinstalled on `ubuntu-24.04`. `GITHUB_TOKEN` already in env, which `gh` picks up automatically.

## Test plan
- [ ] Trigger the `Publish` workflow (or wait for next push to `master`) and confirm `gh api` posts the release-tracker comment.
- [ ] Trigger a downstream caller of `open-pr.sh` / `upload-charts.sh` and confirm `gh pr create` opens the PR and applies the `automerge` label when expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)