### PR TITLE
Clean up publish scripts and OCI workflow

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -19,13 +19,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Set up QEMU
-        id: qemu
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Publish to GitHub Container Registry
         env:
           REGISTRY: ghcr.io/appscode-charts

--- a/hack/fmt.sh
+++ b/hack/fmt.sh
@@ -14,20 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright The Stash Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 set -eou pipefail
 
 export CGO_ENABLED=0

--- a/hack/scripts/open-pr.sh
+++ b/hack/scripts/open-pr.sh
@@ -30,7 +30,7 @@ trap cleanup EXIT
 source $SCRIPT_ROOT/hack/scripts/common.sh
 
 if [ -z "$1" ]; then
-    echo "Missing argument for instller directory."
+    echo "Missing argument for installer directory."
     echo "Correct usage: $SCRIPT_NAME <path_to_installer_repo> <charts_dir, defaults to charts>."
     exit 1
 fi
@@ -66,7 +66,7 @@ fi
 
 while true; do
     cd $SCRIPT_ROOT
-    # remove all unstagged changes
+    # remove all unstaged changes
     git add --all
     git stash || true
     git stash drop || true
@@ -100,35 +100,27 @@ while true; do
     # open pr
     cd $SCRIPT_ROOT
     git add --all
-    # generate commit command
-    ct_cmd="git commit -a -s -m \"Publish ${GITHUB_REPOSITORY}@${GIT_TAG} charts\""
-    ct_cmd="$ct_cmd --message \"ProductLine: $PRODUCT_LINE\""
+    # commit
+    commit_args=(commit -a -s -m "Publish ${GITHUB_REPOSITORY}@${GIT_TAG} charts" --message "ProductLine: $PRODUCT_LINE")
     if [ ! -z "$RELEASE" ]; then
-        ct_cmd="$ct_cmd --message \"Release: $RELEASE\""
+        commit_args+=(--message "Release: $RELEASE")
     fi
     if [ ! -z "$RELEASE_TRACKER" ]; then
-        ct_cmd="$ct_cmd --message \"Release-tracker: $RELEASE_TRACKER\""
+        commit_args+=(--message "Release-tracker: $RELEASE_TRACKER")
     fi
-    # commit
-    eval "$ct_cmd"
+    git "${commit_args[@]}"
     # push successfully or { sleep and retry)
     git push -u origin HEAD || {
         sleep $((1 + RANDOM % 10))
         continue
     }
-    #  open pr
-    pr_cmd=$(
-        cat <<EOF
-gh pr create \
-    --title "Publish $pr_branch charts" \
-    --body "$(git show -s --format=%b)"
-EOF
-    )
+    # open pr
+    pr_args=(pr create --title "Publish $pr_branch charts" --body "$(git show -s --format=%b)")
     # if no Release-tracker: auto merge.
     if [ -z "$RELEASE_TRACKER" ]; then
-        pr_cmd="$pr_cmd --label automerge"
+        pr_args+=(--label automerge)
     fi
-    eval "$pr_cmd" || true
+    gh "${pr_args[@]}" || true
     # if Release-tracker: found, report back.
     if [ ! -z "$RELEASE_TRACKER" ]; then
         parse_url $RELEASE_TRACKER

--- a/hack/scripts/upload-charts.sh
+++ b/hack/scripts/upload-charts.sh
@@ -30,7 +30,7 @@ trap cleanup EXIT
 source $SCRIPT_ROOT/hack/scripts/common.sh
 
 if [ -z "$1" ]; then
-    echo "Missing argument for instller directory."
+    echo "Missing argument for installer directory."
     echo "Correct usage: $SCRIPT_NAME <path_to_installer_repo> <charts_dir, defaults to charts>."
     exit 1
 fi
@@ -67,7 +67,7 @@ fi
 
 while true; do
     cd $SCRIPT_ROOT
-    # remove all unstagged changes
+    # remove all unstaged changes
     git add --all
     git stash || true
     git stash drop || true
@@ -96,35 +96,27 @@ while true; do
     # open pr
     cd $SCRIPT_ROOT
     git add --all
-    # generate commit command
-    ct_cmd="git commit -a -s -m \"Publish ${GITHUB_REPOSITORY}@${GIT_TAG} charts\""
-    ct_cmd="$ct_cmd --message \"ProductLine: $PRODUCT_LINE\""
+    # commit
+    commit_args=(commit -a -s -m "Publish ${GITHUB_REPOSITORY}@${GIT_TAG} charts" --message "ProductLine: $PRODUCT_LINE")
     if [ ! -z "$RELEASE" ]; then
-        ct_cmd="$ct_cmd --message \"Release: $RELEASE\""
+        commit_args+=(--message "Release: $RELEASE")
     fi
     if [ ! -z "$RELEASE_TRACKER" ]; then
-        ct_cmd="$ct_cmd --message \"Release-tracker: $RELEASE_TRACKER\""
+        commit_args+=(--message "Release-tracker: $RELEASE_TRACKER")
     fi
-    # commit
-    eval "$ct_cmd"
+    git "${commit_args[@]}"
     # push successfully or { sleep and retry)
     git push -u origin HEAD || {
         sleep $((1 + RANDOM % 10))
         continue
     }
-    #  open pr
-    pr_cmd=$(
-        cat <<EOF
-gh pr create \
-    --title "Publish $pr_branch charts" \
-    --body "$(git show -s --format=%b)"
-EOF
-    )
+    # open pr
+    pr_args=(pr create --title "Publish $pr_branch charts" --body "$(git show -s --format=%b)")
     # if no Release-tracker: auto merge.
     if [ -z "$RELEASE_TRACKER" ]; then
-        pr_cmd="$pr_cmd --label automerge"
+        pr_args+=(--label automerge)
     fi
-    eval "$pr_cmd" || true
+    gh "${pr_args[@]}" || true
     # if Release-tracker: found, report back.
     if [ ! -z "$RELEASE_TRACKER" ]; then
         parse_url $RELEASE_TRACKER


### PR DESCRIPTION
## Summary
- Replace `eval`-based `git commit` and `gh pr create` commands in `open-pr.sh` / `upload-charts.sh` with `git "${commit_args[@]}"` / `gh "${pr_args[@]}"` arrays so values sourced from git tag bodies (`ProductLine`, `Release`, `Release-tracker`) cannot break out into the shell.
- Drop the unused `setup-qemu-action` and `setup-buildx-action` steps from `publish-oci.yaml` — `helm push` does not need them.
- Fix `instller` / `unstagged` typos in the publish scripts; remove the duplicate license header in `hack/fmt.sh`.

## Test plan
- [ ] Trigger a publish flow (e.g. an installer-driven `open-pr.sh` invocation) and confirm the commit message and PR body still render correctly with `ProductLine` / `Release` / `Release-tracker` markers.
- [ ] Re-run the `OCI` workflow on master after merge and confirm `helm push` to `ghcr.io/appscode-charts` still succeeds without QEMU/Buildx setup.