### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -15,6 +15,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -34,8 +37,8 @@ jobs:
 
       - name: Publish OCI charts
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           REGISTRY_0=oci://ghcr.io/appscode-charts \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -43,8 +45,8 @@ jobs:
 
       - name: Publish charts
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
         run: |
           ./hack/scripts/publish.sh


### PR DESCRIPTION
## Summary

Apply the CI hardening pattern from appscode-cloud/installer#1252.

- Drop the `LGTM_GITHUB_TOKEN` PAT for in-repo git operations; use the default `GITHUB_TOKEN` with `github.actor` and a least-privilege job-level `permissions` block.
- Keep `LGTM_GITHUB_TOKEN` for the ghcr.io docker login (publishing to `appscode-charts` org packages needs cross-org write access).
- All actions in these workflows were already SHA-pinned.

## Test plan

- [ ] Next push to `master` triggers `publish` + `publish-oci` and both succeed.